### PR TITLE
Use bisection search to find U

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+death_probs.csv


### PR DESCRIPTION
This replaces the search over a logarithmically spaced list with a bisection search to tolerance 10⁻⁷.

However I regret to report that this does not close the gap between the output and the numbers in the TPM report:

original:
```
$ julia vax.jl
U using original method: 0.07742636826811271, check R0: 4.00391546726122, wanted 3.984
Total infections were 458092.4
They should be 461893.
Total deaths were 1483.9
They should be 1557.
```

using bisection search:
```
$ julia vax.jl
U using bisection search: 0.07704125072807076, check R0: 3.9840000545952385, wanted 3.984
Total infections were 426522.2
They should be 461893.
Total deaths were 1371.7
They should be 1557.
```